### PR TITLE
Add Associate Heads to team structure and UI

### DIFF
--- a/api/team.js
+++ b/api/team.js
@@ -65,6 +65,7 @@ module.exports = async function handler(req, res) {
 
   const body = {
     heads: teamData.heads.map(withSignedPhoto),
+    associateHeads: (teamData.associateHeads || []).map(withSignedPhoto),
     seniorCoordinators: teamData.seniorCoordinators.map(withSignedPhoto),
     juniorCoordinators: teamData.juniorCoordinators.map(withSignedPhoto),
     generatedAt: new Date().toISOString(),

--- a/src/components/MemberCard.js
+++ b/src/components/MemberCard.js
@@ -5,6 +5,8 @@ const MemberCard = ({ member, role }) => {
   let roleHover;
   if (role === "head") {
     roleHover = "hover:border-accent-yellow hover:shadow-[0_0_20px_#FFD700]";
+  } else if (role === "associate") {
+    roleHover = "hover:border-rose-300 hover:shadow-[0_0_20px_#fda4af]";
   } else if (role === "senior") {
     roleHover = "hover:border-accent-blue hover:shadow-[0_0_20px_#3B82F6]";
   } else if (role === "junior") {

--- a/src/data/team.json
+++ b/src/data/team.json
@@ -79,21 +79,21 @@
       "designation": "Head of Design",
       "year": "3rd Year",
       "department": "Electronics & Communication Engineering"
-    }
-  ],
-  "seniorCoordinators": [
+    },
     {
       "id": 11,
-      "name": "Abhishek S",
-      "photoKey": "SCs/abhishek.png",
-      "designation": "Operations",
+      "name": "Aravindhan S",
+      "photoKey": "Heads/aravindhan.png",
+      "designation": "Tech",
       "year": "3rd Year",
       "department": "Computer Science Engineering"
-    },
+    }
+  ],
+  "associateHeads": [
     {
       "id": 12,
       "name": "Manesh Ram",
-      "photoKey": "SCs/manesh.png",
+      "photoKey": "AHs/manesh.png",
       "designation": "Operations",
       "year": "3rd Year",
       "department": "Computer Science Engineering"
@@ -101,13 +101,47 @@
     {
       "id": 13,
       "name": "Ragotma Ragavendar Nandagopal",
-      "photoKey": "SCs/ragotma.png",
+      "photoKey": "AHs/ragotma.png",
       "designation": "Operations",
       "year": "3rd Year",
       "department": "Computer Science Engineering"
     },
     {
       "id": 14,
+      "name": "Arunprasath M",
+      "photoKey": "AHs/arunprasath.png",
+      "designation": "Operations",
+      "year": "2nd Year",
+      "department": "Mechanical Engineering"
+    },
+    {
+      "id": 15,
+      "name": "Abhishek S",
+      "photoKey": "AHs/abhishek.png",
+      "designation": "Operations",
+      "year": "3rd Year",
+      "department": "Computer Science Engineering"
+    },   
+    {
+      "id": 16,
+      "name": "Srivishnu Rajkrishna",
+      "photoKey": "AHs/shrivishnu.png",
+      "designation": "Marketing",
+      "year": "2nd Year",
+      "department": "Computer Science Engineering"
+    },
+    {
+      "id": 17,
+      "name": "Roshon R",
+      "photoKey": "AHs/roshon.png",
+      "designation": "Design",
+      "year": "3rd Year",
+      "department": "Biomedical Engineering"
+    }
+  ],
+  "seniorCoordinators": [
+    {
+      "id": 18,
       "name": "Samyuktha Venkatasamy",
       "photoKey": "SCs/samyuktha.png",
       "designation": "Operations",
@@ -115,7 +149,7 @@
       "department": "Industrial Engineering"
     },
     {
-      "id": 15,
+      "id": 19,
       "name": "Jeffrey Samuel Raj P",
       "photoKey": "SCs/Jeffrey.png",
       "designation": "Marketing",
@@ -123,7 +157,7 @@
       "department": "Electronics & Communication Engineering"
     },
     {
-      "id": 16,
+      "id": 20,
       "name": "Parthasarathi N S",
       "photoKey": "SCs/parthasarathy.png",
       "designation": "Contents",
@@ -131,7 +165,7 @@
       "department": "Medical Physics"
     },
     {
-      "id": 17,
+      "id": 21,
       "name": "Suvi Sharon",
       "photoKey": "SCs/suvi.png",
       "designation": "Contents",
@@ -139,7 +173,7 @@
       "department": "Computer Science Engineering"
     },
     {
-      "id": 18,
+      "id": 22,
       "name": "Nagarajan S",
       "photoKey": "SCs/nagarajan.png",
       "designation": "Design",
@@ -147,15 +181,7 @@
       "department": "Mechanical Engineering"
     },
     {
-      "id": 19,
-      "name": "Roshon R",
-      "photoKey": "SCs/roshon.png",
-      "designation": "Design",
-      "year": "3rd Year",
-      "department": "Biomedical Engineering"
-    },
-    {
-      "id": 20,
+      "id": 23,
       "name": "A Mohammed Saalih",
       "photoKey": "SCs/saalih.png",
       "designation": "Design",
@@ -163,46 +189,22 @@
       "department": "Computer Science Engineering"
     },
     {
-      "id": 21,
-      "name": "Aravindhan S",
-      "photoKey": "SCs/aravindhan.png",
-      "designation": "Tech",
-      "year": "3rd Year",
+      "id": 24,
+      "name": "Kaviya",
+      "photoKey": "SCs/kaviya.png",
+      "designation": "Design",
+      "year": "2nd Year",
       "department": "Computer Science Engineering"
     }
   ],
   "juniorCoordinators": [
     {
-      "id": 22,
-      "name": "Arunprasath M",
-      "photoKey": "JCs/arunprasath.png",
-      "designation": "Operations",
-      "year": "2nd Year",
-      "department": "Mechanical Engineering"
-    },
-    {
-      "id": 23,
-      "name": "Srivishnu Rajkrishna",
-      "photoKey": "JCs/shrivishnu.png",
-      "designation": "Marketing",
-      "year": "2nd Year",
-      "department": "Computer Science Engineering"
-    },
-    {
-      "id": 24,
+      "id": 25,
       "name": "Sachin C K S",
       "photoKey": "JCs/sachin.png",
       "designation": "Contents",
       "year": "2nd Year",
       "department": "Mechanical Engineering"
-    },
-    {
-      "id": 25,
-      "name": "Kaviya",
-      "photoKey": "JCs/kaviya.png",
-      "designation": "Design",
-      "year": "2nd Year",
-      "department": "Computer Science Engineering"
     },
     {
       "id": 26,

--- a/src/pages/Team.js
+++ b/src/pages/Team.js
@@ -6,6 +6,7 @@ const TEAM_API_URL = TEAM_API_BASE ? `${TEAM_API_BASE}/api/team` : '/api/team';
 
 const emptyRoster = {
   heads: [],
+  associateHeads: [],
   seniorCoordinators: [],
   juniorCoordinators: [],
 };
@@ -32,6 +33,7 @@ const Team = () => {
 
         setTeamData({
           heads: payload.heads || [],
+          associateHeads: payload.associateHeads || [],
           seniorCoordinators: payload.seniorCoordinators || [],
           juniorCoordinators: payload.juniorCoordinators || [],
         });
@@ -55,8 +57,8 @@ const Team = () => {
     };
   }, []);
 
-  const { heads, seniorCoordinators, juniorCoordinators } = teamData;
-  const allMembers = [...heads, ...seniorCoordinators, ...juniorCoordinators];
+  const { heads, associateHeads, seniorCoordinators, juniorCoordinators } = teamData;
+  const allMembers = [...heads, ...associateHeads, ...seniorCoordinators, ...juniorCoordinators];
 
   return (
     <div className="min-h-screen relative overflow-hidden py-8">
@@ -86,10 +88,14 @@ const Team = () => {
         )}
 
         {/* Team Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-16">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6 mb-16">
           <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl p-6 text-center">
             <div className="text-3xl font-bold text-accent-yellow mb-2">{heads.length}</div>
             <div className="text-gray-300">Heads</div>
+          </div>
+          <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl p-6 text-center">
+            <div className="text-3xl font-bold text-rose-300 mb-2">{associateHeads.length}</div>
+            <div className="text-gray-300">Associate Heads</div>
           </div>
           <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl p-6 text-center">
             <div className="text-3xl font-bold text-accent-blue mb-2">{seniorCoordinators.length}</div>
@@ -118,6 +124,24 @@ const Team = () => {
         </div>
 
         <div className="border-t border-white/10 my-6"></div>
+
+        {/* Associate Heads Section */}
+        {associateHeads.length > 0 && (
+          <>
+            <div className="mb-16">
+              <div className="text-center mb-8">
+                <h2 className="text-3xl font-bold text-white mb-4">Associate Heads</h2>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                {associateHeads.map((member) => (
+                  <MemberCard key={member.id} member={member} role="associate" />
+                ))}
+              </div>
+            </div>
+
+            <div className="border-t border-white/10 my-6"></div>
+          </>
+        )}
 
         {/* Senior Coordinators Section */}
         <div className="mb-16">


### PR DESCRIPTION
Introduces an 'associateHeads' section in the team data, API response, and frontend display. Updates MemberCard styling for associate heads and adjusts team stats and member listing to include the new role.